### PR TITLE
RWA metadata extension

### DIFF
--- a/collateral-info.yaml
+++ b/collateral-info.yaml
@@ -215,6 +215,10 @@ collateral-defs:
     collateral-shortname: 6s Capital
     collateral-symbol: RWA001
     collateral-info-url: https://manual.makerdao.com/collateral/real-world-assets-in-detail/6s
+    collateral-stability-fee-type: Fixed
+    collateral-stability-fee-payment-frequency: By the second
+    collateral-documentation: https://ipfs.io/ipfs/QmdmAUTU3sd9VkdfTZNQM6krc9jsKgF2pz7W1qvvfJo1xk
+    collateral-geographical-exposure: US
 
   RWA002: &RWA002
     <<: *CFG-DROP
@@ -223,6 +227,10 @@ collateral-defs:
     collateral-shortname: New Silver DROP
     collateral-symbol: NS-DROP
     collateral-info-url: https://manual.makerdao.com/collateral/real-world-assets-in-detail/new-silver
+    collateral-stability-fee-type: Fixed
+    collateral-stability-fee-payment-frequency: By the second
+    collateral-documentation: https://ipfs.io/ipfs/QmdfuQSLmNFHoxvMjXvv8qbJ2NWprrsvp5L3rGr3JHw18E
+    collateral-geographical-exposure: US
 
   RWA003: &RWA003
     <<: *CFG-DROP
@@ -231,6 +239,10 @@ collateral-defs:
     collateral-shortname: ConsolFreight DROP
     collateral-symbol: CF-DROP
     collateral-info-url: https://manual.makerdao.com/collateral/real-world-assets-in-detail/consolfreight
+    collateral-stability-fee-type: Fixed
+    collateral-stability-fee-payment-frequency: By the second
+    collateral-documentation: https://ipfs.io/ipfs/QmQMNfSbGS8qkJbatQgxMUsz27G8YELWgtXeLs8uFCZoY8
+    collateral-geographical-exposure: US
 
   RWA004: &RWA004
     <<: *CFG-DROP
@@ -239,6 +251,10 @@ collateral-defs:
     collateral-shortname: Harbour Trade Credit DROP
     collateral-symbol: HTC-DROP
     collateral-info-url: https://manual.makerdao.com/collateral/real-world-assets-in-detail/harbour-trade
+    collateral-stability-fee-type: Fixed
+    collateral-stability-fee-payment-frequency: By the second
+    collateral-documentation: https://ipfs.io/ipfs/QmYR2PXwLpdXS8Vp1yS39SPFT1XhmgbsK6XvZ9ApRpNV8M
+    collateral-geographical-exposure: US
 
   RWA005: &RWA005
     <<: *CFG-DROP
@@ -247,6 +263,10 @@ collateral-defs:
     collateral-shortname: FortunaFi DROP
     collateral-symbol: FFT1-DROP
     collateral-info-url: https://manual.makerdao.com/collateral/real-world-assets-in-detail/fortunafi
+    collateral-stability-fee-type: Fixed
+    collateral-stability-fee-payment-frequency: By the second
+    collateral-documentation: https://ipfs.io/ipfs/QmbgDoPn6UcfSDENDqHLgatMFoqXikC8E8it9WaZXyLXmc
+    collateral-geographical-exposure: US
 
   RWA007: &RWA007
     <<: *RWA-CUSTOM
@@ -254,13 +274,23 @@ collateral-defs:
     collateral-longname: Monetalis Clydesdale
     collateral-shortname: Monetalis Clydesdale
     collateral-symbol: RWA007
+    collateral-stability-fee-type: Variable
+    collateral-stability-fee-payment-frequency: One-time
+    collateral-documentation: https://ipfs.io/ipfs/QmRLwB7Ty3ywSzq17GdDdwHvsZGwBg79oUTpSTJGtodToY
+    collateral-geographical-exposure: US
+    vault-closure: Upon governance request
 
   RWA008: &RWA008
     <<: *RWA-CUSTOM
-    collateral-desc: TODO
+    collateral-desc: Covered bonds under French Law backed by home loans and benefiting from a statutory privilege, issued by Societe Generale SFH (SG SFH)
     collateral-longname: Societe Generale
     collateral-shortname: Societe Generale
     collateral-symbol: RWA008
+    stability-fee-type: Fixed
+    stability-fee-payment-frequency: By the second
+    collateral-documentation: https://ipfs.io/ipfs/QmdfzY6p5EpkYMN8wcomF2a1GsJbhkPiRQVRYSPfS4NZtB
+    collateral-geographical-exposure: FR
+    vault-closure: Latest 05/14/2025 
 
   RWA009: &RWA009
     <<: *RWA-CUSTOM
@@ -269,6 +299,11 @@ collateral-defs:
     collateral-shortname: H. V. Bank
     collateral-symbol: RWA009
     collateral-info-url: https://manual.makerdao.com/collateral/real-world-assets-in-detail/hvbank
+    collateral-stability-fee-type: Variable
+    collateral-stability-fee-payment-frequency: Monthly
+    collateral-documentation: https://ipfs.io/ipfs/QmQx3bMtjncka2jUsGwKu7ButuPJFn9yDEEvpg9xZ71ECh
+    collateral-geographical-exposure: US
+    vault-closure: Upon governance request
 
 status-defs:
   Deprecated: &STATUS_DEPRECATED


### PR DESCRIPTION
I've added some extra metadata to all RWAs. Happy to discuss.

Abit of explanation
    collateral-stability-fee-type: Variable or Fixed. Fixed is the SF is set to something greater than 0% as in Centrifuge vaults and SocGen.
    collateral-stability-fee-payment-frequency: Monthly. For Variable stability-fee-type then we need to define a payment frequency greater than "by the second" which is the protocol default stability fee accrual.
    collateral-documentation: https://ipfs.io/ipfs/QmQx3bMtjncka2jUsGwKu7ButuPJFn9yDEEvpg9xZ71ECh . This is the DOC variable IPFS hash turned into a link. This will change as amendments are done to the docs. Maybe markerburn can just pull this from the chain directly.
    collateral-geographical-exposure: US . This is just geographical exposue using ISO3116 Alpha-2 country codes: https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes
    vault-closure: Upon governance request. Mane of our facilities are revolving credit lines such as Centrifuge, HVB, etc, but in SocGen the actual underlying collateral tokenized as OFH tokens has a maturity, so the vault needs to be closed before maturity or we would own the collateral and have to sell it ourselves.




